### PR TITLE
Fix chapter title persistence

### DIFF
--- a/docs/ChapterNameFlow.md
+++ b/docs/ChapterNameFlow.md
@@ -1,0 +1,11 @@
+# Chapter Name Data Flow
+
+```mermaid
+graph TD
+    A[User enters chapter title in UI] --> B[AdminController (Create/Edit)]
+    B --> C[ChapterService]
+    C --> D[ApplyTitleHeader writes Markdown file]
+    D --> E[book.json updated via BookService]
+    E --> F[ManageChapters loads Book]
+    F --> G[UI lists chapters with titles]
+```

--- a/src/BookRenderer.Services/ChapterService.cs
+++ b/src/BookRenderer.Services/ChapterService.cs
@@ -102,6 +102,9 @@ public class ChapterService : IChapterService
             chapter.Content = $"# {chapter.Title}\n\nThis chapter is under construction.";
         }
 
+        // Ensure the first heading matches the provided title
+        chapter.Content = ApplyTitleHeader(chapter.Content, chapter.Title);
+
         Console.WriteLine($"[DEBUG] CreateChapterAsync - Writing file to: {chapterPath}");
         await _fileSystemService.WriteFileAsync(chapterPath, chapter.Content);
         Console.WriteLine($"[DEBUG] CreateChapterAsync - File written successfully");
@@ -140,6 +143,9 @@ public class ChapterService : IChapterService
         }
         
         Console.WriteLine($"[DEBUG] UpdateChapterAsync - Writing file to: {chapterPath}");
+
+        // Ensure the first heading matches the updated title
+        chapter.Content = ApplyTitleHeader(chapter.Content, chapter.Title);
         await _fileSystemService.WriteFileAsync(chapterPath, chapter.Content);
         Console.WriteLine($"[DEBUG] UpdateChapterAsync - File written successfully");
 
@@ -292,6 +298,24 @@ public class ChapterService : IChapterService
                 return trimmed.Substring(2).Trim();
             }
         }        return null;
+    }
+
+    private string ApplyTitleHeader(string content, string title)
+    {
+        if (string.IsNullOrWhiteSpace(content))
+            return $"# {title}\n";
+
+        var lines = content.Split('\n').ToList();
+        if (lines.Count > 0 && lines[0].TrimStart().StartsWith("# "))
+        {
+            lines[0] = "# " + title;
+        }
+        else
+        {
+            lines.Insert(0, "# " + title);
+        }
+
+        return string.Join('\n', lines);
     }
       private string? FindSolutionDirectory(string startingPath)
     {

--- a/src/BookRenderer.Web/Controllers/AdminController.cs
+++ b/src/BookRenderer.Web/Controllers/AdminController.cs
@@ -153,12 +153,10 @@ public class AdminController : BaseController
         if (book == null)
             return NotFound();
 
-        var chapters = await _chapterService.GetChaptersAsync(bookId);
-        
         var viewModel = new ManageChaptersViewModel
         {
             Book = book,
-            Chapters = chapters.OrderBy(c => c.Order).ToList()
+            Chapters = book.Chapters.OrderBy(c => c.Order).ToList()
         };
 
         return View(viewModel);


### PR DESCRIPTION
## Summary
- make ManageChapters use book metadata titles
- keep first markdown heading synced with the chapter title
- add a diagram showing chapter title flow

## Testing
- `dotnet build` *(fails: command not found)*