### PR TITLE
Enable client-side code execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /src/BookRenderer.Services/bin
 /src/BookRenderer.Web/obj
 /src/BookRenderer.Web/bin
+dotnet-install.sh

--- a/src/BookRenderer.Web/Controllers/BaseController.cs
+++ b/src/BookRenderer.Web/Controllers/BaseController.cs
@@ -17,7 +17,7 @@ public class BaseController : Controller
 
     public override async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
     {
-        // Set theme for authenticated users
+        // Set theme and preferences for authenticated users
         if (User?.Identity?.IsAuthenticated == true && _userService != null)
         {
             try
@@ -27,17 +27,20 @@ public class BaseController : Controller
                 {
                     var user = await _userService.GetUserByIdAsync(userId);
                     ViewBag.UserTheme = user?.Preferences?.Theme ?? "light";
+                    ViewBag.UserEnableCodeExecution = user?.Preferences?.EnableCodeExecution ?? false;
                 }
             }
             catch
             {
                 // If there's an error fetching user theme, default to light
                 ViewBag.UserTheme = "light";
+                ViewBag.UserEnableCodeExecution = false;
             }
         }
         else
         {
             ViewBag.UserTheme = "light";
+            ViewBag.UserEnableCodeExecution = false;
         }        await next();
     }
 

--- a/src/BookRenderer.Web/Views/Book/Read.cshtml
+++ b/src/BookRenderer.Web/Views/Book/Read.cshtml
@@ -5,6 +5,8 @@
     var book = ViewBag.Book as BookRenderer.Core.Models.Book;
     var currentChapter = ViewBag.CurrentChapter as BookRenderer.Core.Models.Chapter;
     var allChapters = ViewBag.AllChapters as List<BookRenderer.Core.Models.Chapter>;
+    var allowCodeExecution = book?.Settings?.AllowCodeExecution ?? false;
+    var allowedLanguages = string.Join(',', book?.Settings?.AllowedCodeLanguages ?? new List<string>());
 }
 
 <div class="row">
@@ -59,7 +61,7 @@
 
             <!-- Chapter content -->
             <div class="chapter-body">
-                <div id="chapter-content" data-book-id="@book?.Id" data-chapter-id="@currentChapter?.Id">
+                <div id="chapter-content" data-book-id="@book?.Id" data-chapter-id="@currentChapter?.Id" data-allow-code-execution="@allowCodeExecution.ToString().ToLower()" data-allowed-languages="@allowedLanguages">
                     <!-- Content will be loaded here -->
                     <div class="text-center py-5">
                         <div class="spinner-border" role="status">
@@ -123,9 +125,5 @@
             }
         }
 
-        function executeCode(button) {
-            // TODO: Implement code execution
-            console.log('Code execution not yet implemented');
-        }
     </script>
 }

--- a/src/BookRenderer.Web/Views/Shared/_Layout.cshtml
+++ b/src/BookRenderer.Web/Views/Shared/_Layout.cshtml
@@ -13,6 +13,7 @@
     {
         <meta name="user-theme" content="@(ViewBag.UserTheme ?? "light")" />
     }
+    <meta name="user-enable-code-execution" content="@(ViewBag.UserEnableCodeExecution ?? false)" />
 </head>
 <body>
     <header>        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-dark bg-dark border-bottom box-shadow mb-3">
@@ -87,6 +88,7 @@
     <script src="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/contrib/auto-render.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
     <script src="~/js/theme-switcher.js" asp-append-version="true"></script>
+    <script src="~/js/code-executor.js" asp-append-version="true"></script>
     <script src="~/js/site.js" asp-append-version="true"></script>
     @await RenderSectionAsync("Scripts", required: false)
 </body>

--- a/src/BookRenderer.Web/wwwroot/js/code-executor.js
+++ b/src/BookRenderer.Web/wwwroot/js/code-executor.js
@@ -1,0 +1,120 @@
+// code-executor.js
+// Helper functions for running code snippets in the browser
+
+window.CodeExecutor = (function(){
+    let pyodideReady = null;
+
+    async function loadScript(url){
+        return new Promise((resolve, reject)=>{
+            const s = document.createElement('script');
+            s.src = url;
+            s.onload = resolve;
+            s.onerror = reject;
+            document.head.appendChild(s);
+        });
+    }
+
+    async function getPyodide(){
+        if(pyodideReady) return pyodideReady;
+        if(!window.loadPyodide){
+            await loadScript('https://cdn.jsdelivr.net/pyodide/v0.25.1/full/pyodide.js');
+        }
+        pyodideReady = window.loadPyodide({indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.25.1/full/'});
+        return pyodideReady;
+    }
+
+    async function ensureTypeScript(){
+        if(!window.ts){
+            await loadScript('https://cdnjs.cloudflare.com/ajax/libs/typescript/5.3.3/typescript.min.js');
+        }
+    }
+
+    function runInIframe(jsCode){
+        return new Promise((resolve)=>{
+            const iframe = document.createElement('iframe');
+            iframe.style.display = 'none';
+            iframe.sandbox = 'allow-scripts';
+            document.body.appendChild(iframe);
+            let output = '';
+            iframe.contentWindow.console.log = (...args)=>{ output += args.join(' ') + '\n'; };
+            iframe.contentWindow.console.error = (...args)=>{ output += args.join(' ') + '\n'; };
+            iframe.onload = () => {
+                setTimeout(()=>{
+                    document.body.removeChild(iframe);
+                    resolve(output.trim());
+                },10);
+            };
+            const doc = iframe.contentDocument;
+            doc.open();
+            doc.write(`<script>try{${jsCode}}catch(e){console.error(e);}</script>`);
+            doc.close();
+        });
+    }
+
+    async function runPython(code){
+        const pyodide = await getPyodide();
+        await pyodide.loadPackagesFromImports(code);
+        return pyodide.runPython(code).toString();
+    }
+
+    async function runJavaScript(code){
+        return runInIframe(code);
+    }
+
+    async function runTypeScript(code){
+        await ensureTypeScript();
+        const js = window.ts.transpile(code);
+        return runInIframe(js);
+    }
+
+    async function runCSharp(code){
+        if(window.DotNet && DotNet.invokeMethodAsync){
+            try{
+                return await DotNet.invokeMethodAsync('BookRenderer.Web', 'ExecuteSnippet', code);
+            }catch(e){
+                return e.toString();
+            }
+        }
+        return 'C# execution environment not available.';
+    }
+
+    return {
+        execute: async function(language, code){
+            language = language.toLowerCase();
+            if(language === 'javascript' || language === 'js') return runJavaScript(code);
+            if(language === 'typescript' || language === 'ts') return runTypeScript(code);
+            if(language === 'python' || language === 'py') return runPython(code);
+            if(language === 'csharp' || language === 'cs') return runCSharp(code);
+            return 'Unsupported language: ' + language;
+        }
+    };
+})();
+
+// Convenience wrapper used by site.js and views
+window.executeCode = async function(button){
+    const block = button.closest('.executable-code-block');
+    if(!block) return;
+    const language = (block.dataset.language || '').toLowerCase();
+    const codeElement = block.querySelector('pre > code');
+    const code = codeElement ? codeElement.textContent : '';
+    const outputDiv = block.querySelector('.code-output');
+    const chapter = document.getElementById('chapter-content');
+    const allowed = (chapter.dataset.allowedLanguages || '').split(',').map(l=>l.trim().toLowerCase()).filter(l=>l);
+    const allowExec = chapter.dataset.allowCodeExecution === 'true';
+    const userAllow = document.querySelector('meta[name="user-enable-code-execution"]')?.content === 'True' || document.querySelector('meta[name="user-enable-code-execution"]')?.content === 'true';
+
+    outputDiv.style.display = 'block';
+
+    if(!(allowExec && userAllow && allowed.includes(language))){
+        outputDiv.textContent = 'Code execution not allowed.';
+        return;
+    }
+
+    outputDiv.textContent = 'Running...';
+    try{
+        const result = await window.CodeExecutor.execute(language, code);
+        outputDiv.textContent = result;
+    }catch(err){
+        outputDiv.textContent = err.toString();
+    }
+};

--- a/src/BookRenderer.Web/wwwroot/js/site.js
+++ b/src/BookRenderer.Web/wwwroot/js/site.js
@@ -55,8 +55,3 @@ function reinitializeLibraries() {
     }
 }
 
-// Function for executing code blocks (placeholder for future implementation)
-function executeCode(button) {
-    console.log('Code execution not yet implemented');
-    // TODO: Implement code execution functionality
-}


### PR DESCRIPTION
## Summary
- expose user code execution preference in BaseController
- include preference meta tag and new script reference in layout
- surface book execution settings in `Read.cshtml`
- implement runtime support in new `code-executor.js`
- delegate execution from site.js and view
- remove stray dotnet installer script

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840c6850954832e92677a9aecf6112d